### PR TITLE
Update upgrade.py

### DIFF
--- a/python/samba/upgrade.py
+++ b/python/samba/upgrade.py
@@ -471,10 +471,10 @@ def upgrade_from_samba3(samba3, logger, targetdir, session_info=None,
     if samba3.lp.get("passdb backend").split(":")[0].strip() == "ldapsam":
         base_dn = samba3.lp.get("ldap suffix")
         ldapuser = samba3.lp.get("ldap admin dn")
-        ldappass = secrets_db.get_ldap_bind_pw(ldapuser)
-        if ldappass is None:
+        b_ldappass = secrets_db.get_ldap_bind_pw(ldapuser)
+        if b_ldappass is None:
             raise ProvisioningError("ldapsam passdb backend detected but no LDAP Bind PW found in secrets.tdb for user %s.  Please point this tool at the secrets.tdb that was used by the previous installation.")
-        ldappass = ldappass.strip('\x00')
+        ldappass = b_ldappass.decode('ASCII').strip('\x00')
         ldap = True
     else:
         ldapuser = None


### PR DESCRIPTION
secrets_db.get_ldap_bind_pw() return binary string on python3.6.
but ldappass expects ascii string . So I add encode method.

## Samba is moving to GitLab
The samba project is moving to GitLab, please consider opening a merge request there instead.
Instructions for setting up can be found at: https://wiki.samba.org/index.php/Samba_CI_on_gitlab
The GitLab repository can be found here: https://gitlab.com/samba-team/samba
